### PR TITLE
Hardware button fix

### DIFF
--- a/lib/features/choose_color/presentation/pages/choose_color.dart
+++ b/lib/features/choose_color/presentation/pages/choose_color.dart
@@ -57,7 +57,7 @@ class ChooseColor extends StatelessWidget {
                   ),
                 ),
               );
-              AutoRouter.of(context).push(const EmptyGame());
+              AutoRouter.of(context).replaceAll([const EmptyGame()]);
             },
           ),
           const SizedBox(height: 20),


### PR DESCRIPTION
Previously, pressing the hardware "back" button after selecting a color had the problem of creating a second player. Now, after selecting a color, pressing this button will minimize the application.